### PR TITLE
Improve wave difficulty and AI behavior

### DIFF
--- a/lua/arcade_spawner/client/health_bars.lua
+++ b/lua/arcade_spawner/client/health_bars.lua
@@ -65,7 +65,7 @@ local function UpdateEnemyCache()
                         distance = distance,
                         health = health,
                         maxHealth = maxHealth,
-                        healthPercent = health / maxHealth,
+                        healthPercent = math.Clamp(health / maxHealth, 0, 1),
                         rarity = ent.RarityType or "Common",
                         position = ent:GetPos() + HEALTH_BAR_CONFIG.offset
                     })
@@ -109,7 +109,7 @@ local function DrawHealthBar(enemyData)
     local pos = enemyData.position
     local screenPos = pos:ToScreen()
     
-    if not screenPos.visible then return end
+    if screenPos.visible == false then return end
     
     local distance = enemyData.distance
     local alpha = 255
@@ -168,11 +168,16 @@ local function DrawHealthBar(enemyData)
     end
     
     -- Rarity indicator stripe
-    if rarity != "Common" then
+    if rarity ~= "Common" then
         local rarityColor = GetRarityColor(rarity)
         rarityColor.a = alpha * 0.8
         draw.RoundedBox(0, x, y - 3, w, 2, rarityColor)
     end
+
+    -- Hitpoint text
+    local hpText = string.format("%d/%d", enemyData.health, enemyData.maxHealth)
+    draw.SimpleText(hpText, "ArcadeHUD_Small", x + w / 2, y - 8,
+                   Color(255, 255, 255, alpha), TEXT_ALIGN_CENTER, TEXT_ALIGN_BOTTOM)
     
     -- Damage indicators (optional)
     if enemyData.healthPercent < 0.3 then

--- a/lua/arcade_spawner/client/hud.lua
+++ b/lua/arcade_spawner/client/hud.lua
@@ -12,7 +12,8 @@ HUD.SessionData = {
     sessionTime = 0,
     startTime = 0,
     enemiesRemaining = 0,
-    enemiesTarget = 10
+    enemiesTarget = 10,
+    isBossWave = false
 }
 HUD.Notifications = {}
 HUD.FontsCreated = false
@@ -129,11 +130,12 @@ function HUD.InitializeNetworking()
             local wave = net.ReadInt(16)
             local target = net.ReadInt(16)
             local isBoss = net.ReadBool()
-            
+
             HUD.SessionData.currentWave = wave
             HUD.SessionData.enemiesTarget = target
             HUD.SessionData.enemiesRemaining = target
-            
+            HUD.SessionData.isBossWave = isBoss
+
             if isBoss then
                 HUD.AddNotification(">>> BOSS WAVE " .. wave .. " INCOMING! <<<", Color(255, 50, 50), 5)
             else
@@ -384,9 +386,11 @@ function HUD.DrawMainInfo(scrW, scrH)
     draw.SimpleText("=== ARCADE MODE ===", "ArcadeHUD_Title", padding + 15, padding + 15, 
                    Color(255, 255, 255), TEXT_ALIGN_LEFT)
     
-    local waveText = string.format("WAVE: %d", HUD.SessionData.currentWave)
-    draw.SimpleText(waveText, "ArcadeHUD_Medium", padding + 15, padding + 45, 
-                   Color(255, 215, 0), TEXT_ALIGN_LEFT)
+    local waveLabel = HUD.SessionData.isBossWave and "BOSS" or tostring(HUD.SessionData.currentWave)
+    local waveColor = HUD.SessionData.isBossWave and Color(255, 60, 60) or Color(255, 215, 0)
+    local waveText = string.format("WAVE: %s", waveLabel)
+    draw.SimpleText(waveText, "ArcadeHUD_Medium", padding + 15, padding + 45,
+                   waveColor, TEXT_ALIGN_LEFT)
     
     local killText = string.format("KILLS: %d", HUD.SessionData.enemiesKilled)
     draw.SimpleText(killText, "ArcadeHUD_Medium", padding + 15, padding + 70, 


### PR DESCRIPTION
## Summary
- adjust wave system with a dynamic difficulty multiplier
- update wave start and completion handling
- broadcast enemy count after each spawn
- clamp enemy health bar values and fix visibility checks
- add enemy patrolling logic that uses navmesh for roam points
- fix HUD wave updates and show health numbers
- remove invalid net messages and start patrol sooner

## Testing
- `grep -n "DynamicDifficulty" -n lua/arcade_spawner/core/spawner.lua`
- `luac -p lua/arcade_spawner/core/spawner.lua`
- `luac -p lua/arcade_spawner/core/enemy_manager.lua`
- `luac -p lua/arcade_spawner/client/hud.lua`
- `luac -p lua/arcade_spawner/client/health_bars.lua`


------
https://chatgpt.com/codex/tasks/task_e_684624d88dd08326b029d22ad99a040b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Health bars now display current and maximum hit points as text above the bar.
  - Boss waves are visually distinguished in the HUD with a "BOSS" label and color changes.
  - Enemies now exhibit patrol behavior when idle, improving AI movement.
  - Dynamic difficulty scaling adjusts enemy counts per wave based on player performance.

- **Bug Fixes**
  - Corrected Lua inequality operators for improved compatibility.
  - Health percentages are now properly clamped to valid ranges.
  - Fixed HUD and AI logic to ensure accurate state updates and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->