### PR TITLE
Improve wave scaling and patrol AI

### DIFF
--- a/lua/arcade_spawner/client/damage_numbers.lua
+++ b/lua/arcade_spawner/client/damage_numbers.lua
@@ -1,0 +1,55 @@
+-- addons/arcade_spawner/lua/arcade_spawner/client/damage_numbers.lua
+-- Simple damage number display
+
+if not ArcadeSpawner then ArcadeSpawner = {} end
+ArcadeSpawner.DamageNumbers = ArcadeSpawner.DamageNumbers or {}
+local DamageNumbers = ArcadeSpawner.DamageNumbers
+
+DamageNumbers.Active = {}
+
+net.Receive("ArcadeSpawner_DamageNumber", function()
+    local pos = net.ReadVector()
+    local dmg = net.ReadInt(16)
+    local isKill = net.ReadBool()
+
+    local text = tostring(dmg)
+    if isKill then
+        text = text .. " キル!"
+    else
+        text = text .. " ダメ"
+    end
+
+    table.insert(DamageNumbers.Active, {
+        pos = pos,
+        vel = Vector(0, 0, 40),
+        text = text,
+        start = CurTime(),
+        life = 1.2,
+        alpha = 255
+    })
+end)
+
+hook.Add("Think", "ArcadeSpawner_UpdateDamageNumbers", function()
+    local ft = FrameTime()
+    for i = #DamageNumbers.Active, 1, -1 do
+        local d = DamageNumbers.Active[i]
+        d.pos = d.pos + d.vel * ft
+        local progress = (CurTime() - d.start) / d.life
+        d.alpha = 255 * math.Clamp(1 - progress, 0, 1)
+        if progress >= 1 then
+            table.remove(DamageNumbers.Active, i)
+        end
+    end
+end)
+
+hook.Add("HUDPaint", "ArcadeSpawner_DrawDamageNumbers", function()
+    for _, d in ipairs(DamageNumbers.Active) do
+        local screen = d.pos:ToScreen()
+        if screen.visible ~= false then
+            draw.SimpleTextOutlined(d.text, "ArcadeHUD_Large", screen.x, screen.y,
+                Color(255, 80, 80, d.alpha), TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER, 2, Color(0,0,0,d.alpha))
+        end
+    end
+end)
+
+print("[Arcade Spawner] ✨ Damage number client module loaded!")

--- a/lua/arcade_spawner/client/effects.lua
+++ b/lua/arcade_spawner/client/effects.lua
@@ -53,8 +53,8 @@ local function CreateSafeEmitter(pos, maxParticles)
     
     local success, emitter = pcall(ParticleEmitter, pos)
     if success and emitter then
+        -- Only SetNearClip is available on the emitter
         emitter:SetNearClip(24, 32)
-        emitter:SetFarClip(1000, 1200)
         
         -- Auto-cleanup
         timer.Simple(5, function()
@@ -431,7 +431,7 @@ hook.Add("PostDrawOpaqueRenderables", "ArcadeSpawner_EnhancedGlow", function()
         local currentTime = CurTime()
         
         for _, ent in ipairs(ents.GetAll()) do
-            if IsValid(ent) and ent.IsArcadeEnemy and ent.RarityType and ent.RarityType != "Common" then
+            if IsValid(ent) and ent.IsArcadeEnemy and ent.RarityType and ent.RarityType ~= "Common" then
                 local glowColors = {
                     ["Uncommon"] = {color = Color(30, 255, 30), intensity = 15},
                     ["Rare"] = {color = Color(30, 144, 255), intensity = 25},

--- a/lua/arcade_spawner/client/health_bars.lua
+++ b/lua/arcade_spawner/client/health_bars.lua
@@ -56,16 +56,16 @@ local function UpdateEnemyCache()
             local distance = playerPos:Distance(ent:GetPos())
             
             if distance <= HEALTH_BAR_CONFIG.maxDistance then
-                local health = ent:Health()
-                local maxHealth = ent:GetMaxHealth()
-                
-                if health > 0 and maxHealth > 0 then
+                local maxHealth = math.max(ent:GetMaxHealth(), ent:Health(), 1)
+                local health = math.Clamp(ent:Health(), 0, maxHealth)
+
+                if health > 0 then
                     table.insert(HealthBars.EnemyCache, {
                         entity = ent,
                         distance = distance,
                         health = health,
                         maxHealth = maxHealth,
-                        healthPercent = health / maxHealth,
+                        healthPercent = math.Clamp(health / maxHealth, 0, 1),
                         rarity = ent.RarityType or "Common",
                         position = ent:GetPos() + HEALTH_BAR_CONFIG.offset
                     })
@@ -109,7 +109,7 @@ local function DrawHealthBar(enemyData)
     local pos = enemyData.position
     local screenPos = pos:ToScreen()
     
-    if not screenPos.visible then return end
+    if screenPos.visible == false then return end
     
     local distance = enemyData.distance
     local alpha = 255
@@ -168,11 +168,16 @@ local function DrawHealthBar(enemyData)
     end
     
     -- Rarity indicator stripe
-    if rarity != "Common" then
+    if rarity ~= "Common" then
         local rarityColor = GetRarityColor(rarity)
         rarityColor.a = alpha * 0.8
         draw.RoundedBox(0, x, y - 3, w, 2, rarityColor)
     end
+
+    -- Hitpoint text
+    local hpText = string.format("%d/%d", enemyData.health, enemyData.maxHealth)
+    draw.SimpleText(hpText, "ArcadeHUD_Large", x + w / 2, y - 12,
+                   Color(255, 255, 255, alpha), TEXT_ALIGN_CENTER, TEXT_ALIGN_BOTTOM)
     
     -- Damage indicators (optional)
     if enemyData.healthPercent < 0.3 then
@@ -188,10 +193,6 @@ hook.Add("HUDPaint", "ArcadeSpawner_HealthBars", function()
     UpdateEnemyCache()
     
     if #HealthBars.EnemyCache == 0 then return end
-    
-    -- Set up 3D context
-    cam.Start3D()
-    cam.End3D()
     
     -- Draw all health bars
     for _, enemyData in ipairs(HealthBars.EnemyCache) do

--- a/lua/arcade_spawner/client/hud.lua
+++ b/lua/arcade_spawner/client/hud.lua
@@ -12,7 +12,8 @@ HUD.SessionData = {
     sessionTime = 0,
     startTime = 0,
     enemiesRemaining = 0,
-    enemiesTarget = 10
+    enemiesTarget = 10,
+    isBossWave = false
 }
 HUD.Notifications = {}
 HUD.FontsCreated = false
@@ -21,6 +22,40 @@ HUD.Initialized = false
 HUD.NetworkInitialized = false
 HUD.DirectionIndicators = {}
 HUD.LastDamageTime = {}
+HUD.MaxTrackerDistance = 4000
+HUD.AmbientSound = nil
+HUD.WorkshopProgress = nil
+
+function HUD.StartAmbience()
+    if HUD.AmbientSound or not GetConVar("arcade_creepy_fx"):GetBool() then return end
+    if not LocalPlayer or not IsValid(LocalPlayer()) then return end
+
+    HUD.AmbientSound = CreateSound(LocalPlayer(), "ambient/halloween/ghosts.wav")
+    if HUD.AmbientSound then
+        HUD.AmbientSound:PlayEx(0.5, 90)
+    end
+
+    ArcadeSpawner.Effects = ArcadeSpawner.Effects or {}
+    ArcadeSpawner.Effects.ScreenEffects.ambience = {
+        effect = {
+            ["$pp_colour_brightness"] = -0.05,
+            ["$pp_colour_contrast"] = 1.1,
+            ["$pp_colour_colour"] = 0.6
+        },
+        endTime = math.huge,
+        fadeTime = 2
+    }
+end
+
+function HUD.StopAmbience()
+    if HUD.AmbientSound then
+        HUD.AmbientSound:Stop()
+        HUD.AmbientSound = nil
+    end
+    if ArcadeSpawner and ArcadeSpawner.Effects and ArcadeSpawner.Effects.ScreenEffects then
+        ArcadeSpawner.Effects.ScreenEffects.ambience = nil
+    end
+end
 
 -- ═══════════════════════════════════════════════════════════════
 -- ENHANCED AUTO-INITIALIZATION SYSTEM
@@ -106,6 +141,7 @@ function HUD.InitializeNetworking()
             HUD.SessionData.currentWave = 1
             HUD.SessionData.enemiesRemaining = net.ReadInt(16) or 10
             HUD.SessionData.enemiesTarget = HUD.SessionData.enemiesRemaining
+            HUD.StartAmbience()
             HUD.AddNotification(">>> ARCADE MODE ACTIVATED <<<", Color(0, 255, 0), 4)
             print("[Arcade Spawner] 📡 Session started! Target: " .. HUD.SessionData.enemiesTarget)
         end,
@@ -114,8 +150,9 @@ function HUD.InitializeNetworking()
             local kills = net.ReadInt(32)
             local wave = net.ReadInt(16)
             local sessionTime = net.ReadInt(16)
-            
+
             HUD.SessionActive = false
+            HUD.StopAmbience()
             
             local minutes = math.floor(sessionTime / 60)
             local seconds = sessionTime % 60
@@ -129,11 +166,12 @@ function HUD.InitializeNetworking()
             local wave = net.ReadInt(16)
             local target = net.ReadInt(16)
             local isBoss = net.ReadBool()
-            
+
             HUD.SessionData.currentWave = wave
             HUD.SessionData.enemiesTarget = target
             HUD.SessionData.enemiesRemaining = target
-            
+            HUD.SessionData.isBossWave = isBoss
+
             if isBoss then
                 HUD.AddNotification(">>> BOSS WAVE " .. wave .. " INCOMING! <<<", Color(255, 50, 50), 5)
             else
@@ -142,16 +180,25 @@ function HUD.InitializeNetworking()
             
             print("[Arcade Spawner] 📡 Wave " .. wave .. " started! Target: " .. target)
         end,
+
+        ["ArcadeSpawner_WaveComplete"] = function()
+            local wave = net.ReadInt(16)
+            HUD.AddNotification(string.format(">>> WAVE %d COMPLETE <<<", wave), Color(100,255,100), 4)
+            HUD.SessionData.enemiesRemaining = 0
+            HUD.SessionData.currentWave = wave
+            HUD.SessionData.waveCompleteTime = CurTime()
+        end,
         
         ["ArcadeSpawner_EnemyKilled"] = function()
             local totalKills = net.ReadInt(32)
             local currentWave = net.ReadInt(16)
             local xp = net.ReadInt(16)
             local isBoss = net.ReadBool()
-            
+            local remaining = net.ReadInt(16)
+
             HUD.SessionData.enemiesKilled = totalKills
             HUD.SessionData.currentWave = currentWave
-            HUD.SessionData.enemiesRemaining = math.max(0, HUD.SessionData.enemiesRemaining - 1)
+            HUD.SessionData.enemiesRemaining = remaining
             
             if isBoss then
                 HUD.AddNotification(">>> BOSS DEFEATED! <<<", Color(255, 215, 0), 3)
@@ -170,6 +217,19 @@ function HUD.InitializeNetworking()
             local newLevel = net.ReadInt(16)
             HUD.PlayerData.level = newLevel
             HUD.AddNotification(">>> LEVEL UP! NOW LEVEL " .. newLevel .. " <<<", Color(255, 215, 0), 4)
+        end,
+
+        ["ArcadeSpawner_WorkshopProgress"] = function()
+            local count = net.ReadInt(16)
+            local total = net.ReadInt(16)
+            HUD.WorkshopProgress = {count = count, total = total, timestamp = CurTime()}
+            if count >= total then
+                timer.Simple(2, function()
+                    if HUD.WorkshopProgress and HUD.WorkshopProgress.count >= HUD.WorkshopProgress.total then
+                        HUD.WorkshopProgress = nil
+                    end
+                end)
+            end
         end
     }
     
@@ -223,7 +283,7 @@ function HUD.UpdateEnemyTracker()
             local enemyPos = ent:GetPos()
             local distance = playerPos:Distance(enemyPos)
             
-            if distance <= 2500 then
+            if distance <= HUD.MaxTrackerDistance then
                 local direction = (enemyPos - playerPos):GetNormalized()
                 local angle = math.deg(math.atan2(direction.y, direction.x))
                 local relativeAngle = angle - playerAng.y
@@ -260,7 +320,7 @@ function HUD.UpdateDirectionIndicators()
         -- Player took damage, find nearest enemy for damage indicator
         if #HUD.EnemyTracker > 0 then
             local closest = HUD.EnemyTracker[1]
-            if closest.distance <= 1500 then
+            if closest.distance <= HUD.MaxTrackerDistance then
                 table.insert(HUD.DirectionIndicators, {
                     angle = closest.angle,
                     type = "damage",
@@ -289,6 +349,20 @@ function HUD.UpdateDirectionIndicators()
                 endTime = currentTime + 0.2
             })
         end
+    end
+
+    -- Always indicate the closest enemy
+    if HUD.EnemyTracker[1] then
+        local nearest = HUD.EnemyTracker[1]
+        table.insert(HUD.DirectionIndicators, {
+            angle = nearest.angle,
+            type = "nearest",
+            intensity = 1.0,
+            distance = nearest.distance,
+            rarity = nearest.rarity,
+            color = HUD.GetRarityColor(nearest.rarity),
+            endTime = currentTime + 0.2
+        })
     end
     
     -- Clean up expired indicators
@@ -375,8 +449,8 @@ function HUD.DrawMainInfo(scrW, scrH)
     local boxWidth = 380
     local boxHeight = 160
     
-    draw.RoundedBox(8, padding - 2, padding - 2, boxWidth + 4, boxHeight + 4, Color(100, 150, 255, 30))
-    draw.RoundedBox(6, padding, padding, boxWidth, boxHeight, Color(0, 0, 0, 180))
+    draw.RoundedBox(8, padding - 2, padding - 2, boxWidth + 4, boxHeight + 4, Color(80, 80, 100, 120))
+    draw.RoundedBox(6, padding, padding, boxWidth, boxHeight, Color(10, 10, 20, 200))
     
     local pulse = math.sin(CurTime() * 2) * 0.3 + 0.7
     draw.RoundedBox(8, padding - 2, padding - 2, boxWidth + 4, 2, Color(100, 150, 255, 255 * pulse))
@@ -384,9 +458,11 @@ function HUD.DrawMainInfo(scrW, scrH)
     draw.SimpleText("=== ARCADE MODE ===", "ArcadeHUD_Title", padding + 15, padding + 15, 
                    Color(255, 255, 255), TEXT_ALIGN_LEFT)
     
-    local waveText = string.format("WAVE: %d", HUD.SessionData.currentWave)
-    draw.SimpleText(waveText, "ArcadeHUD_Medium", padding + 15, padding + 45, 
-                   Color(255, 215, 0), TEXT_ALIGN_LEFT)
+    local waveLabel = HUD.SessionData.isBossWave and "BOSS" or tostring(HUD.SessionData.currentWave)
+    local waveColor = HUD.SessionData.isBossWave and Color(255, 60, 60) or Color(255, 215, 0)
+    local waveText = string.format("WAVE: %s", waveLabel)
+    draw.SimpleText(waveText, "ArcadeHUD_Medium", padding + 15, padding + 45,
+                   waveColor, TEXT_ALIGN_LEFT)
     
     local killText = string.format("KILLS: %d", HUD.SessionData.enemiesKilled)
     draw.SimpleText(killText, "ArcadeHUD_Medium", padding + 15, padding + 70, 
@@ -412,7 +488,7 @@ function HUD.DrawMainInfo(scrW, scrH)
     local progressX = padding + 15
     local progressY = padding + 140
     
-    draw.RoundedBox(4, progressX, progressY, progressWidth, progressHeight, Color(30, 30, 30, 200))
+    draw.RoundedBox(4, progressX, progressY, progressWidth, progressHeight, Color(30, 30, 40, 220))
     
     if HUD.SessionData.enemiesTarget > 0 then
         local progress = 1 - (HUD.SessionData.enemiesRemaining / HUD.SessionData.enemiesTarget)
@@ -507,9 +583,14 @@ function HUD.DrawDirectionIndicators(scrW, scrH)
             -- Distance text for close enemies
             if indicator.distance and indicator.distance <= 400 then
                 local distText = string.format("%dm", math.floor(indicator.distance / 50))
-                draw.SimpleText(distText, "ArcadeHUD_Small", x, y + 25, 
+                draw.SimpleText(distText, "ArcadeHUD_Small", x, y + 25,
                                Color(255, 255, 255, alpha * 0.8), TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER)
             end
+        elseif indicator.type == "nearest" then
+            local arrow = HUD.GetDirectionalIndicator(indicator.angle)
+            local nx = centerX + math.cos(rad) * (radius - 30)
+            local ny = centerY + math.sin(rad) * (radius - 30)
+            draw.SimpleText(arrow, "ArcadeHUD_Large", nx, ny, color, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER)
         end
     end
     
@@ -596,6 +677,20 @@ function HUD.DrawNotifications(scrW, scrH)
     end
 end
 
+function HUD.DrawWorkshopProgress(scrW, scrH)
+    local prog = HUD.WorkshopProgress
+    if not prog or prog.total == 0 then return end
+
+    local w, h = 300, 18
+    local x, y = scrW / 2 - w / 2, scrH - 60
+    local pct = math.Clamp(prog.count / prog.total, 0, 1)
+
+    draw.RoundedBox(4, x, y, w, h, Color(20, 20, 20, 220))
+    draw.RoundedBox(4, x, y, w * pct, h, Color(100, 200, 255, 220))
+    local txt = string.format("WORKSHOP MODELS %d/%d", prog.count, prog.total)
+    draw.SimpleText(txt, "ArcadeHUD_Small", x + w / 2, y + h / 2, Color(255, 255, 255), TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER)
+end
+
 -- ═══════════════════════════════════════════════════════════════
 -- MAIN HUD HOOK
 -- ═══════════════════════════════════════════════════════════════
@@ -616,6 +711,7 @@ hook.Add("HUDPaint", "ArcadeSpawner_Enhanced_HUD", function()
         HUD.DrawDirectionIndicators(scrW, scrH)
         HUD.DrawHealthArmor(scrW, scrH)
         HUD.DrawNotifications(scrW, scrH)
+        HUD.DrawWorkshopProgress(scrW, scrH)
     end)
     
     if not success then

--- a/lua/arcade_spawner/core/enemy_manager.lua
+++ b/lua/arcade_spawner/core/enemy_manager.lua
@@ -5,6 +5,10 @@ if not ArcadeSpawner then ArcadeSpawner = {} end
 ArcadeSpawner.EnemyManager = ArcadeSpawner.EnemyManager or {}
 local Manager = ArcadeSpawner.EnemyManager
 
+if SERVER then
+    util.AddNetworkString("ArcadeSpawner_WorkshopProgress")
+end
+
 -- ═══════════════════════════════════════════════════════════════
 -- ENHANCED STATE MANAGEMENT
 -- ═══════════════════════════════════════════════════════════════
@@ -15,20 +19,13 @@ Manager.ActiveEnemies = {}
 Manager.EnemyStats = {}
 Manager.ValidationInProgress = false
 
--- ═══════════════════════════════════════════════════════════════
--- BULLETPROOF WORKSHOP MODEL VALIDATION SYSTEM
--- ═══════════════════════════════════════════════════════════════
-function Manager.ScanWorkshopModels()
-    if Manager.ValidationInProgress then return end
-    Manager.ValidationInProgress = true
-    
-    print("[Arcade Spawner] 🔍 Scanning workshop models for validation...")
-    
+-- Collect potential workshop models for validation
+function Manager.CollectWorkshopModels()
     local workshopModels = {}
+
     local playerModels = list.Get("PlayerOptionsModel")
     local npcList = list.Get("NPC")
-    
-    -- Scan player models that might be NPCs
+
     if playerModels then
         for _, data in pairs(playerModels) do
             if data and data.Model then
@@ -40,8 +37,7 @@ function Manager.ScanWorkshopModels()
             end
         end
     end
-    
-    -- Scan NPC list for custom models
+
     if npcList then
         for className, data in pairs(npcList) do
             if data and data.Model and not Manager.IsVanillaModel(data.Model) then
@@ -54,7 +50,102 @@ function Manager.ScanWorkshopModels()
             end
         end
     end
+
+    -- Recursively search the models folder for additional .mdl files
+    local maxModels = ArcadeSpawner.Config.MaxWorkshopModels or 100
+    local function AddModelsFromPath(path, depth)
+        depth = depth or 0
+        if depth > 5 or #workshopModels >= maxModels then return end
+
+        local files, dirs = file.Find(path .. "*.mdl", "GAME")
+        for _, f in ipairs(files) do
+            if #workshopModels >= maxModels then return end
+            local modelPath = path .. f
+            if not Manager.IsVanillaModel(modelPath) then
+                table.insert(workshopModels, {
+                    model = modelPath,
+                    source = "filesystem",
+                    name = modelPath
+                })
+            end
+        end
+
+        local _, subdirs = file.Find(path .. "*", "GAME")
+        for _, d in ipairs(subdirs) do
+            if d ~= "." and d ~= ".." then
+                AddModelsFromPath(path .. d .. "/", depth + 1)
+                if #workshopModels >= maxModels then return end
+            end
+        end
+    end
+
+    AddModelsFromPath("models/")
+
+    return workshopModels
+end
+
+-- Asynchronous scan to avoid hitches
+function Manager.AsyncScanWorkshopModels()
+    if Manager.ValidationInProgress then return end
+    Manager.ValidationInProgress = true
+
+    print("[Arcade Spawner] 🔍 Async scanning workshop models...")
+
+    local workshopModels = Manager.CollectWorkshopModels()
+    local index = 1
+    local validated, rejected = 0, 0
+    local total = #workshopModels
+
+    net.Start("ArcadeSpawner_WorkshopProgress")
+    net.WriteInt(0, 16)
+    net.WriteInt(total, 16)
+    net.Broadcast()
+
+    timer.Create("ArcadeSpawner_WorkshopScan", 0.1, 0, function()
+        local data = workshopModels[index]
+        if not data then
+            print("[Arcade Spawner] ✅ Workshop validation complete: " .. validated .. " validated, " .. rejected .. " rejected")
+            Manager.ValidationInProgress = false
+            timer.Remove("ArcadeSpawner_WorkshopScan")
+
+            net.Start("ArcadeSpawner_WorkshopProgress")
+            net.WriteInt(total, 16)
+            net.WriteInt(total, 16)
+            net.Broadcast()
+            return
+        end
+
+        if validated < ArcadeSpawner.Config.MaxWorkshopModels then
+            local result = Manager.ValidateWorkshopModel(data)
+            if result.valid then
+                table.insert(Manager.WorkshopModels, result.data)
+                validated = validated + 1
+            else
+                rejected = rejected + 1
+                print("[Arcade Spawner] ❌ Rejected: " .. data.model .. " (" .. result.reason .. ")")
+            end
+        end
+
+        index = index + 1
+
+        net.Start("ArcadeSpawner_WorkshopProgress")
+        net.WriteInt(math.min(validated + rejected, total), 16)
+        net.WriteInt(total, 16)
+        net.Broadcast()
+    end)
+end
+
+-- ═══════════════════════════════════════════════════════════════
+-- BULLETPROOF WORKSHOP MODEL VALIDATION SYSTEM
+-- ═══════════════════════════════════════════════════════════════
+function Manager.ScanWorkshopModels()
+    if Manager.ValidationInProgress then return end
+    Manager.ValidationInProgress = true
     
+    print("[Arcade Spawner] 🔍 Scanning workshop models for validation...")
+
+    local workshopModels = Manager.CollectWorkshopModels()
+
     print("[Arcade Spawner] 📦 Found " .. #workshopModels .. " potential workshop models")
     
     -- Validate each model
@@ -459,6 +550,12 @@ function Manager.CreateAdvancedEnemy(pos, wave, forceRarity, attempt)
         enemy:SetModel(modelData.model)
         enemy:Spawn()
         enemy:Activate()
+
+        -- Validate animation sequences to avoid T-poses
+        local idleSeq = enemy:SelectWeightedSequence(ACT_IDLE)
+        if idleSeq <= 0 then
+            error("Model missing idle sequence")
+        end
         
         -- IMMEDIATE validation after spawn
         if not IsValid(enemy) or not enemy:Alive() then
@@ -491,8 +588,8 @@ function Manager.CreateAdvancedEnemy(pos, wave, forceRarity, attempt)
     
     if not success then
         print("[Arcade Spawner] ❌ Enemy creation failed: " .. tostring(errorMsg))
-        if IsValid(enemy) then 
-            SafeRemove(enemy) 
+        if IsValid(enemy) then
+            SafeRemoveEntity(enemy)
             enemy = nil
         end
     end
@@ -542,12 +639,13 @@ function Manager.ApplyDynamicScaling(enemy, rarity, wave)
     local config = ArcadeSpawner.Config
     local rarityData = config.RaritySystem[rarity] or config.RaritySystem["Common"]
     local waveScaling = config.WaveScaling
+    local difficulty = (ArcadeSpawner.Spawner and ArcadeSpawner.Spawner.DynamicDifficulty) or 1.0
     
     -- Calculate wave multipliers with caps
-    local waveHealthMult = math.min(1 + ((wave - 1) * waveScaling.HealthScale), waveScaling.MaxHealthMultiplier)
-    local waveSpeedMult = math.min(1 + ((wave - 1) * waveScaling.SpeedScale), waveScaling.MaxSpeedMultiplier)
-    local waveAccuracyMult = math.min(1 + ((wave - 1) * waveScaling.AccuracyScale), waveScaling.MaxAccuracyMultiplier)
-    local waveDamageMult = math.min(1 + ((wave - 1) * waveScaling.DamageScale), waveScaling.MaxDamageMultiplier)
+    local waveHealthMult = math.min(1 + ((wave - 1) * waveScaling.HealthScale), waveScaling.MaxHealthMultiplier) * difficulty
+    local waveSpeedMult = math.min(1 + ((wave - 1) * waveScaling.SpeedScale), waveScaling.MaxSpeedMultiplier) * difficulty
+    local waveAccuracyMult = math.min(1 + ((wave - 1) * waveScaling.AccuracyScale), waveScaling.MaxAccuracyMultiplier) * difficulty
+    local waveDamageMult = math.min(1 + ((wave - 1) * waveScaling.DamageScale), waveScaling.MaxDamageMultiplier) * difficulty
     
     pcall(function()
         -- Health scaling with workshop model consideration
@@ -687,7 +785,7 @@ function Manager.SetupEnemyRelationships(enemy)
         
         -- Make ALL arcade enemies neutral to each other
         for _, ent in pairs(ents.GetAll()) do
-            if IsValid(ent) and ent.IsArcadeEnemy and ent != enemy then
+            if IsValid(ent) and ent.IsArcadeEnemy and ent ~= enemy then
                 enemy:AddEntityRelationship(ent, D_NU, 0)
                 ent:AddEntityRelationship(enemy, D_NU, 0)
             end
@@ -722,6 +820,7 @@ function Manager.SetupAdvancedAI(enemy)
         enemy.AimPredictionEnabled = ArcadeSpawner.Config.AISettings.AimPrediction
         enemy.LastPosition = enemy:GetPos()
         enemy.StuckCounter = 0
+        enemy.NextPatrolUpdate = CurTime() + math.Rand(0.5, 1.0)
         
         -- Movement speed enhancement
         if enemy.SpeedMultiplier then
@@ -771,10 +870,31 @@ function Manager.AdvancedAIThink(enemy)
         enemy.LastPlayerSeen = CurTime()
         enemy.LastKnownPlayerPos = playerPos
     end
+
+    -- Proactively seek players if none spotted recently
+    if not canSeePlayer and CurTime() - (enemy.LastPlayerSeen or 0) > 8 then
+        enemy.LastPlayerSeen = CurTime()
+        local seek = Manager.GetRandomPatrolPoint(enemy)
+        if seek then Manager.MoveToPosition(enemy, seek) end
+    end
     
     -- Squad tactics decision making
     local behavior = Manager.DetermineSquadBehavior(enemy, nearestPlayer, distance, canSeePlayer)
     Manager.ExecuteAIBehavior(enemy, behavior, nearestPlayer)
+
+    -- Encourage wandering if idle for too long
+    enemy.LastMoveCheck = enemy.LastMoveCheck or CurTime()
+    enemy.LastCheckedPos = enemy.LastCheckedPos or enemyPos
+    if enemy:GetPos():Distance(enemy.LastCheckedPos) < 10 then
+        if CurTime() - enemy.LastMoveCheck > 3 then
+            local patrol = Manager.GetRandomPatrolPoint(enemy)
+            if patrol then Manager.MoveToPosition(enemy, patrol) end
+            enemy.LastMoveCheck = CurTime()
+        end
+    else
+        enemy.LastCheckedPos = enemy:GetPos()
+        enemy.LastMoveCheck = CurTime()
+    end
     
     -- Anti-stuck system
     Manager.CheckAndHandleStuck(enemy)
@@ -820,8 +940,13 @@ function Manager.DetermineSquadBehavior(enemy, player, distance, canSeePlayer)
         return "seek_cover"
     elseif distance < config.ChaseRadius then
         return "chase"
-    else
+    elseif enemy.LastKnownPlayerPos and CurTime() - enemy.LastPlayerSeen < 5 then
+        if enemy.LastKnownPlayerPos == vector_origin then
+            return "patrol"
+        end
         return "search"
+    else
+        return "patrol"
     end
 end
 
@@ -857,10 +982,18 @@ function Manager.ExecuteAIBehavior(enemy, behavior, player)
             enemy:SetSchedule(SCHED_CHASE_ENEMY)
             
         elseif behavior == "search" then
-            if enemy.LastKnownPlayerPos then
+            if enemy.LastKnownPlayerPos and enemy.LastKnownPlayerPos ~= vector_origin then
                 Manager.MoveToPosition(enemy, enemy.LastKnownPlayerPos)
             else
                 enemy:SetSchedule(SCHED_IDLE_WANDER)
+            end
+        elseif behavior == "patrol" then
+            if not enemy.NextPatrolUpdate or CurTime() >= enemy.NextPatrolUpdate then
+                local patrolPos = Manager.GetRandomPatrolPoint(enemy)
+                if patrolPos then
+                    Manager.MoveToPosition(enemy, patrolPos)
+                end
+                enemy.NextPatrolUpdate = CurTime() + 3
             end
         end
     end)
@@ -1023,6 +1156,9 @@ function Manager.IsPositionValidAdvanced(pos)
     return not finalTrace.StartSolid
 end
 
+-- Simple alias for general validity checks
+Manager.IsPositionValid = Manager.IsPositionValidAdvanced
+
 function Manager.DetermineRarity(wave)
     local roll = math.random(1, 100)
     local waveBonus = math.min(wave * 2, 30) -- Increase rare spawns with wave
@@ -1078,6 +1214,25 @@ function Manager.MoveToPosition(enemy, targetPos)
         enemy:SetLastPosition(targetPos)
         enemy:SetSchedule(SCHED_FORCED_GO_RUN)
     end)
+end
+
+function Manager.GetRandomPatrolPoint(enemy)
+    local players = player.GetAll()
+    if #players > 0 then
+        local ply = table.Random(players)
+        local offset = VectorRand() * math.random(500, 1200)
+        local pos = ply:GetPos() + offset
+        if Manager.IsPositionValid(pos) then return pos end
+    end
+
+    local areas = navmesh.GetAllNavAreas()
+    if areas and #areas > 0 then
+        local area = table.Random(areas)
+        return area:GetCenter()
+    end
+
+    local offset = Vector(math.random(-800,800), math.random(-800,800), 0)
+    return enemy:GetPos() + offset
 end
 
 function Manager.CheckAndHandleStuck(enemy)

--- a/lua/arcade_spawner/core/pathfinding.lua
+++ b/lua/arcade_spawner/core/pathfinding.lua
@@ -158,7 +158,7 @@ function Pathfinding.BuildNavMesh()
     local connectionRadius = resolution * 1.5
     for key1, node1 in pairs(Pathfinding.NavMesh) do
         for key2, node2 in pairs(Pathfinding.NavMesh) do
-            if key1 != key2 then
+            if key1 ~= key2 then
                 local dist = node1.pos:Distance(node2.pos)
                 if dist <= connectionRadius then
                     -- Check line of sight

--- a/lua/arcade_spawner/core/spawner.lua
+++ b/lua/arcade_spawner/core/spawner.lua
@@ -14,11 +14,15 @@ Spawner.CurrentWave = 1
 Spawner.EnemiesKilled = 0
 Spawner.ActiveEnemies = {}
 Spawner.WaveEnemiesSpawned = 0
+Spawner.WaveEnemiesKilled = 0
 Spawner.WaveEnemiesTarget = 10
+Spawner.WaveEnemiesRemaining = 10
 Spawner.SessionStartTime = 0
 Spawner.LastBossWave = 0
 Spawner.MapBounds = nil
 Spawner.LastPlayerPositions = {}
+Spawner.DynamicDifficulty = 1.0
+Spawner.WaveStartTime = 0
 
 -- Enhanced network strings
 util.AddNetworkString("ArcadeSpawner_SessionStart")
@@ -26,6 +30,7 @@ util.AddNetworkString("ArcadeSpawner_SessionEnd")
 util.AddNetworkString("ArcadeSpawner_WaveStart")
 util.AddNetworkString("ArcadeSpawner_EnemyKilled")
 util.AddNetworkString("ArcadeSpawner_BossWave")
+util.AddNetworkString("ArcadeSpawner_WaveComplete")
 
 -- ═══════════════════════════════════════════════════════════════
 -- INTELLIGENT SPAWN POINT GENERATION
@@ -416,12 +421,16 @@ function ArcadeSpawner.StartSession()
     Spawner.CurrentWave = 1
     Spawner.EnemiesKilled = 0
     Spawner.WaveEnemiesSpawned = 0
+    Spawner.WaveEnemiesKilled = 0
     Spawner.SessionStartTime = CurTime()
+    Spawner.WaveStartTime = CurTime()
+    Spawner.DynamicDifficulty = 1.0
     Spawner.ActiveEnemies = {}
     Spawner.LastBossWave = 0
     
     -- Calculate wave target
     Spawner.WaveEnemiesTarget = Spawner.CalculateWaveTarget(1)
+    Spawner.WaveEnemiesRemaining = Spawner.WaveEnemiesTarget
     
     -- Perform map analysis
     local success = Spawner.PerformIntelligentMapAnalysis()
@@ -503,14 +512,13 @@ function Spawner.InitializeSpawnSystem()
     
     -- Initial spawn burst
     timer.Simple(2, function()
-        if Spawner.Active then
-            for i = 1, 4 do
-                timer.Simple(i * 0.8, function()
-                    if Spawner.Active then
-                        Spawner.SpawnIntelligentEnemy()
-                    end
-                end)
-            end
+        if not Spawner.Active then return end
+        for i = 0, 3 do
+            timer.Simple(i * 0.5, function()
+                if Spawner.Active and Spawner.WaveEnemiesSpawned < Spawner.WaveEnemiesTarget then
+                    Spawner.SpawnIntelligentEnemy()
+                end
+            end)
         end
     end)
 end
@@ -523,25 +531,23 @@ function Spawner.ExecuteSpawnCycle()
     local maxEnemies = GetConVar("arcade_max_enemies"):GetInt()
     local remainingInWave = Spawner.WaveEnemiesTarget - Spawner.WaveEnemiesSpawned
     local currentEnemies = #Spawner.ActiveEnemies
-    
+
     if remainingInWave > 0 and currentEnemies < maxEnemies then
-        local spawnCount = math.min(
-            3, -- Max spawns per cycle
-            remainingInWave,
-            maxEnemies - currentEnemies
-        )
-        
+        local spawnLeft = math.max(0, Spawner.WaveEnemiesTarget - Spawner.WaveEnemiesSpawned)
+        local spawnCount = math.min(2, spawnLeft, maxEnemies - currentEnemies)
+
         for i = 1, spawnCount do
-            timer.Simple(i * 0.4, function()
-                if Spawner.Active then
-                    Spawner.SpawnIntelligentEnemy()
-                end
-            end)
+            if Spawner.WaveEnemiesSpawned >= Spawner.WaveEnemiesTarget then break end
+            if not Spawner.SpawnIntelligentEnemy() then
+                break
+            end
         end
     end
 end
 
 function Spawner.SpawnIntelligentEnemy()
+    if Spawner.WaveEnemiesSpawned >= Spawner.WaveEnemiesTarget then return end
+
     -- Select optimal spawn point
     local spawnPoint = Spawner.SelectOptimalSpawnPoint()
     if not spawnPoint then
@@ -565,8 +571,8 @@ function Spawner.SpawnIntelligentEnemy()
     if IsValid(enemy) then
         table.insert(Spawner.ActiveEnemies, enemy)
         Spawner.WaveEnemiesSpawned = Spawner.WaveEnemiesSpawned + 1
-        
-        print("[Arcade Spawner] ✅ Spawned " .. (enemy.RarityType or "Common") .. 
+
+        print("[Arcade Spawner] ✅ Spawned " .. (enemy.RarityType or "Common") ..
               " enemy (" .. Spawner.WaveEnemiesSpawned .. "/" .. Spawner.WaveEnemiesTarget .. ")")
         
         return enemy
@@ -601,38 +607,30 @@ function Spawner.ManageWaveProgression()
     Spawner.ActiveEnemies = validEnemies
     
     -- FIXED: Accurate remaining calculation
-    local enemiesRemaining = math.max(0, (Spawner.WaveEnemiesTarget - Spawner.WaveEnemiesSpawned) + aliveEnemies)
+    local enemiesRemaining = math.max(0, Spawner.WaveEnemiesTarget - Spawner.WaveEnemiesKilled)
+    Spawner.WaveEnemiesRemaining = enemiesRemaining
     
-    -- Update HUD with accurate count
-    if aliveEnemies != Spawner.LastAliveCount then
-        net.Start("ArcadeSpawner_EnemyKilled")
-        net.WriteInt(Spawner.EnemiesKilled, 32)
-        net.WriteInt(Spawner.CurrentWave, 16) 
-        net.WriteInt(0, 16) -- XP (will be handled separately)
-        net.WriteBool(false) -- Not boss
-        net.Broadcast()
-        
+    -- Track enemy count for HUD updates
+    if aliveEnemies ~= Spawner.LastAliveCount then
         Spawner.LastAliveCount = aliveEnemies
-        print("[Arcade Spawner] 📡 Enemy killed! Remaining: " .. enemiesRemaining)
     end
     
-    -- Check wave completion: all spawned AND all killed
-    local waveComplete = (Spawner.WaveEnemiesSpawned >= Spawner.WaveEnemiesTarget) and (aliveEnemies == 0)
+    -- Check wave completion
+    local waveComplete = (Spawner.WaveEnemiesKilled >= Spawner.WaveEnemiesTarget) and (aliveEnemies == 0)
     
     if waveComplete then
         print("[Arcade Spawner] 🌊 Wave " .. Spawner.CurrentWave .. " COMPLETE!")
-        timer.Simple(3, function() -- Longer pause for effect cleanup
-            if Spawner.Active then
-                Spawner.StartNextWave()
-            end
-        end)
+        Spawner.HandleWaveComplete()
     end
 end
 
 function Spawner.StartNextWave()
     Spawner.CurrentWave = Spawner.CurrentWave + 1
     Spawner.WaveEnemiesSpawned = 0
+    Spawner.WaveEnemiesKilled = 0
     Spawner.WaveEnemiesTarget = Spawner.CalculateWaveTarget(Spawner.CurrentWave)
+    Spawner.WaveEnemiesRemaining = Spawner.WaveEnemiesTarget
+    Spawner.WaveStartTime = CurTime()
     
     local isBossWave = Spawner.IsBossWave(Spawner.CurrentWave)
     
@@ -659,6 +657,36 @@ function Spawner.StartNextWave()
         net.WriteInt(Spawner.CurrentWave, 16)
         net.Broadcast()
     end
+end
+
+function Spawner.HandleWaveComplete()
+    local completionTime = CurTime() - (Spawner.WaveStartTime or CurTime())
+    Spawner.UpdateDynamicDifficulty(completionTime)
+
+    Spawner.WaveEnemiesRemaining = 0
+
+    net.Start("ArcadeSpawner_WaveComplete")
+    net.WriteInt(Spawner.CurrentWave, 16)
+    net.Broadcast()
+
+    timer.Simple(3, function()
+        if Spawner.Active then
+            Spawner.StartNextWave()
+        end
+    end)
+end
+
+function Spawner.UpdateDynamicDifficulty(completionTime)
+    local expected = 25 + (Spawner.CurrentWave * 5)
+    local diff = Spawner.DynamicDifficulty or 1.0
+
+    if completionTime < expected * 0.75 then
+        diff = math.min(diff + 0.1, 2.0)
+    elseif completionTime > expected * 1.25 then
+        diff = math.max(diff - 0.05, 0.5)
+    end
+
+    Spawner.DynamicDifficulty = diff
 end
 
 function Spawner.IsBossWave(wave)
@@ -694,24 +722,35 @@ end
 -- UTILITY FUNCTIONS
 -- ═══════════════════════════════════════════════════════════════
 function Spawner.CalculateWaveTarget(wave)
-    local baseEnemies = 10
+    local baseEnemies = 8 + (#player.GetAll() * 2)
     local scalePerWave = 1.4
     local maxEnemies = 80
-    
-    local target = math.floor(baseEnemies + (wave - 1) * scalePerWave)
+
+    local difficulty = Spawner.DynamicDifficulty or 1.0
+
+    local target = math.floor((baseEnemies + (wave - 1) * scalePerWave) * difficulty)
     return math.min(target, maxEnemies)
 end
 
 function Spawner.SelectOptimalSpawnPoint()
     if #Spawner.SpawnPoints == 0 then return nil end
-    
+
     -- Filter available points
     local availablePoints = {}
-    
+    local players = Spawner.LastPlayerPositions or {}
+
     for _, point in ipairs(Spawner.SpawnPoints) do
         if Spawner.IsSpawnPointAvailable(point.pos) then
             -- Add multiple entries based on quality for weighted selection
             local weight = math.max(math.floor(point.quality or 5), 1)
+
+            -- Bias toward points closer to players but outside min distance
+            for _, pPos in ipairs(players) do
+                local dist = point.pos:Distance(pPos)
+                if dist < 1000 then weight = weight + 2 end
+                if dist < 600 then weight = weight + 1 end
+            end
+
             for i = 1, weight do
                 table.insert(availablePoints, point)
             end
@@ -812,6 +851,10 @@ end
 hook.Add("OnNPCKilled", "ArcadeSpawner_EnemyKilled", function(npc, attacker, inflictor)
     if IsValid(npc) and npc.IsArcadeEnemy and Spawner.Active then
         Spawner.EnemiesKilled = Spawner.EnemiesKilled + 1
+        Spawner.WaveEnemiesKilled = (Spawner.WaveEnemiesKilled or 0) + 1
+        if Spawner.WaveEnemiesKilled > Spawner.WaveEnemiesTarget then
+            Spawner.WaveEnemiesKilled = Spawner.WaveEnemiesTarget
+        end
         
         -- Handle XP if player killed
         local xp = 30
@@ -823,16 +866,20 @@ hook.Add("OnNPCKilled", "ArcadeSpawner_EnemyKilled", function(npc, attacker, inf
         end
         
         -- FIXED: Notify clients with comprehensive data
+        local remaining = math.max(0, Spawner.WaveEnemiesTarget - Spawner.WaveEnemiesKilled)
+        Spawner.WaveEnemiesRemaining = remaining
+
         net.Start("ArcadeSpawner_EnemyKilled")
         net.WriteInt(Spawner.EnemiesKilled, 32)        -- Total kills
         net.WriteInt(Spawner.CurrentWave, 16)          -- Current wave
         net.WriteInt(xp, 16)                           -- XP gained
         net.WriteBool(npc.RarityType == "Mythic")      -- Is boss
+        net.WriteInt(remaining, 16)                    -- Remaining enemies
         net.Broadcast()
         
-        print("[Arcade Spawner] Enemy killed! Total: " .. Spawner.EnemiesKilled .. 
-              " | Wave: " .. Spawner.CurrentWave .. 
-              " | Remaining: " .. (Spawner.WaveEnemiesTarget - Spawner.WaveEnemiesSpawned))
+        print("[Arcade Spawner] Enemy killed! Total: " .. Spawner.EnemiesKilled ..
+              " | Wave: " .. Spawner.CurrentWave ..
+              " | Remaining: " .. remaining)
     end
 end)
 

--- a/lua/autorun/arcade_spawner_init.lua
+++ b/lua/autorun/arcade_spawner_init.lua
@@ -37,6 +37,7 @@ local function ForceInitialize()
         AddCSLuaFile("arcade_spawner/client/hud.lua")
         AddCSLuaFile("arcade_spawner/client/health_bars.lua")
         AddCSLuaFile("arcade_spawner/client/effects.lua")
+        AddCSLuaFile("arcade_spawner/client/damage_numbers.lua")
         AddCSLuaFile("arcade_spawner/core/config.lua")
         
         -- Create console variables with enhanced defaults
@@ -47,7 +48,9 @@ local function ForceInitialize()
         CreateConVar("arcade_ai_accuracy", "1.0", FCVAR_ARCHIVE, "AI accuracy multiplier")
         CreateConVar("arcade_spawn_rate", "0.8", FCVAR_ARCHIVE, "Enemy spawn interval")
         CreateConVar("arcade_workshop_validation", "1", FCVAR_ARCHIVE, "Enable workshop model validation")
+        CreateConVar("arcade_auto_start", "0", FCVAR_ARCHIVE, "Automatically start session on map load")
         CreateConVar("arcade_auto_hud", "1", FCVAR_ARCHIVE, "Auto-initialize HUD on map load")
+        CreateConVar("arcade_creepy_fx", "1", FCVAR_ARCHIVE, "Enable creepy ambience effects")
         SafeInclude("arcade_spawner/server/loot_system.lua")
         
         print("[Arcade Spawner] 🎮 Server systems initialized!")
@@ -59,6 +62,9 @@ local function ForceInitialize()
         SafeInclude("arcade_spawner/client/hud.lua")
         SafeInclude("arcade_spawner/client/health_bars.lua")
         SafeInclude("arcade_spawner/client/effects.lua")
+        SafeInclude("arcade_spawner/client/damage_numbers.lua")
+
+        CreateClientConVar("arcade_creepy_fx", "1", true, false, "Enable creepy ambience effects")
         
         print("[Arcade Spawner] 🎯 Client systems initialized!")
     end
@@ -66,6 +72,14 @@ local function ForceInitialize()
     ArcadeSpawner.Initialized = true
     print("[Arcade Spawner] ✅ BULLETPROOF system initialized successfully!")
     print("==============================================")
+
+    if SERVER and GetConVar("arcade_auto_start"):GetBool() and ArcadeSpawner.StartSession then
+        timer.Simple(1, function()
+            if not ArcadeSpawner.Spawner.Active then
+                ArcadeSpawner.StartSession()
+            end
+        end)
+    end
 end
 
 -- ═══════════════════════════════════════════════════════════════
@@ -192,10 +206,21 @@ if SERVER then
     
     concommand.Add("arcade_validate_workshop", function(ply, cmd, args)
         if IsValid(ply) and not ply:IsAdmin() then return end
-        
-        if ArcadeSpawner.EnemyManager and ArcadeSpawner.EnemyManager.ScanWorkshopModels then
-            local count = ArcadeSpawner.EnemyManager.ScanWorkshopModels()
-            local msg = "🔍 Workshop scan complete: " .. count .. " models validated"
+
+        if ArcadeSpawner.EnemyManager and ArcadeSpawner.EnemyManager.AsyncScanWorkshopModels then
+            ArcadeSpawner.EnemyManager.AsyncScanWorkshopModels()
+            local msg = "🔍 Workshop scan started"
+            print("[Arcade Spawner] " .. msg)
+            if IsValid(ply) then ply:ChatPrint("[Arcade Spawner] " .. msg) end
+        end
+    end)
+
+    concommand.Add("arcade_rescan_models", function(ply, cmd, args)
+        if IsValid(ply) and not ply:IsAdmin() then return end
+
+        if ArcadeSpawner.EnemyManager and ArcadeSpawner.EnemyManager.AsyncScanWorkshopModels then
+            ArcadeSpawner.EnemyManager.AsyncScanWorkshopModels()
+            local msg = "🔍 Workshop rescan started"
             print("[Arcade Spawner] " .. msg)
             if IsValid(ply) then ply:ChatPrint("[Arcade Spawner] " .. msg) end
         end


### PR DESCRIPTION
## Summary
- track remaining enemies on server and send consistent wave info
- ensure next waves set remaining target properly
- enemies proactively seek players if idle for too long and patrol further
- subtle dark theme tweaks for main HUD box

## Testing
- `luac5.1 -p lua/arcade_spawner/core/spawner.lua`
- `luac5.1 -p lua/arcade_spawner/core/enemy_manager.lua`
- `luac5.1 -p lua/arcade_spawner/client/hud.lua`
- `luac5.1 -p lua/arcade_spawner/client/health_bars.lua`
- `luac5.1 -p lua/autorun/arcade_spawner_init.lua`


------
https://chatgpt.com/codex/tasks/task_e_684624d88dd08326b029d22ad99a040b